### PR TITLE
Fix docs requested by @mattsse in commandfuture.rs

### DIFF
--- a/src/handler/commandfuture.rs
+++ b/src/handler/commandfuture.rs
@@ -20,9 +20,8 @@ pin_project! {
         rx_command: oneshot::Receiver<M>,
         #[pin]
         target_sender: mpsc::Sender<TargetMessage>,
-        // We need delay to be pinned because it's a future
-        // and we need to be able to poll it
-        // it is used to timeout the command if page was closed while waiting for response
+
+        /// Used to timeout the command if the page was closed while waiting for response
         #[pin]
         delay: futures_timer::Delay,
 


### PR DESCRIPTION
To be detected as documentation, a commment needs three slashes, I also made it more succint, as the `#[pin]` attribute doesn't really need to be documented, (as it is already documented in the standard library) only the `delay` itself